### PR TITLE
Fix keypress commands

### DIFF
--- a/monkeylib.py
+++ b/monkeylib.py
@@ -68,7 +68,8 @@ class Monkey:
             return buf
 
     def keyevent(self, key):
-        res = self.send("press %d" % key)
+        #res = self.send("press %d" % key)
+        res = self.send("press %s" % key)
         return res == "OK"
 
     def sendtext(self, txt):

--- a/monkeyrunner.py
+++ b/monkeyrunner.py
@@ -381,7 +381,9 @@ class MonkeyDevice:
 
         # todo: parse 'instrument' result.
         return self.adb.shell(" ".join(quotespaces(_) for _ in cmdline))
-
+    def resolvekeyname(self, name):
+        if name=='KEYCODE_HOME':
+            return 3
     def press(self, name, type=DOWN_AND_UP):
         """
         Send a key event to the specified key
@@ -392,7 +394,8 @@ class MonkeyDevice:
                    typing a key, send DOWN_AND_UP
         """
         if type==self.DOWN_AND_UP:
-            self.mlib.keyevent(self.resolvekeyname(name))
+            #self.mlib.keyevent(self.resolvekeyname(name))
+            self.mlib.keyevent(name)
         else:
             self.mlib.key(type, self.resolvekeyname(name))
 


### PR DESCRIPTION
I guess the resolvekeyname(name) function call is just a placeholder for a function that converts the string keycode to an integer, but we don't actually need to do that conversion. This PR just passes the string directly and it works fine for me on my first tests.

Let me know what you think and thanks for this project, I'm glad I found it!